### PR TITLE
Refactor some changes based on your work

### DIFF
--- a/merge-request-integration-ce/src/main/kotlin/net/ntworld/mergeRequestIntegrationIdeCE/DiffExtension.kt
+++ b/merge-request-integration-ce/src/main/kotlin/net/ntworld/mergeRequestIntegrationIdeCE/DiffExtension.kt
@@ -1,0 +1,8 @@
+package net.ntworld.mergeRequestIntegrationIdeCE
+
+import com.intellij.openapi.components.ServiceManager
+import net.ntworld.mergeRequestIntegrationIde.comments.DiffExtensionBase
+
+class DiffExtension : DiffExtensionBase(
+    ServiceManager.getService(CommunityApplicationService::class.java)
+)

--- a/merge-request-integration-ce/src/main/resources/META-INF/plugin.xml
+++ b/merge-request-integration-ce/src/main/resources/META-INF/plugin.xml
@@ -12,6 +12,7 @@
     <extensions defaultExtensionNs="com.intellij">
         <applicationService serviceImplementation="net.ntworld.mergeRequestIntegrationIdeCE.CommunityApplicationService"/>
         <projectService serviceImplementation="net.ntworld.mergeRequestIntegrationIdeCE.CommunityProjectService"/>
+        <diff.DiffExtension implementation="net.ntworld.mergeRequestIntegrationIdeCE.DiffExtension"/>
 
         <projectConfigurable id="merge-request-integration-ce"
                              displayName="Merge Request Integration CE"

--- a/merge-request-integration-core/src/main/kotlin/net/ntworld/mergeRequestIntegrationIde/comments/DiffExtensionBase.kt
+++ b/merge-request-integration-core/src/main/kotlin/net/ntworld/mergeRequestIntegrationIde/comments/DiffExtensionBase.kt
@@ -6,9 +6,11 @@ import com.intellij.diff.FrameDiffTool
 import com.intellij.diff.requests.ContentDiffRequest
 import com.intellij.diff.requests.DiffRequest
 import com.intellij.diff.tools.util.base.DiffViewerBase
+import net.ntworld.mergeRequestIntegrationIde.service.ApplicationService
 
-
-class DiffViewerCommentsExtension : DiffExtension() {
+open class DiffExtensionBase(
+    private val applicationService: ApplicationService
+) : DiffExtension() {
 
     override fun onViewerCreated(
             viewer: FrameDiffTool.DiffViewer,
@@ -16,9 +18,8 @@ class DiffViewerCommentsExtension : DiffExtension() {
             request: DiffRequest
     ) {
         context.project?.takeIf { viewer is DiffViewerBase && request is ContentDiffRequest }?.let {
-            ReviewCommentsSupport.getInstance(it)
-                    .installExtensions(viewer as DiffViewerBase, request as ContentDiffRequest)
-
+            DiffExtensionInstaller(applicationService, context, viewer, request).install()
         }
     }
+
 }

--- a/merge-request-integration-core/src/main/kotlin/net/ntworld/mergeRequestIntegrationIde/comments/DiffExtensionInstaller.kt
+++ b/merge-request-integration-core/src/main/kotlin/net/ntworld/mergeRequestIntegrationIde/comments/DiffExtensionInstaller.kt
@@ -1,58 +1,58 @@
 package net.ntworld.mergeRequestIntegrationIde.comments
 
 import com.intellij.codeInsight.daemon.OutsidersPsiFileSupport
-import com.intellij.diff.requests.ContentDiffRequest
+import com.intellij.diff.DiffContext
+import com.intellij.diff.FrameDiffTool
+import com.intellij.diff.requests.DiffRequest
 import com.intellij.diff.tools.fragmented.UnifiedDiffViewer
 import com.intellij.diff.tools.fragmented.UnifiedFragmentBuilder
 import com.intellij.diff.tools.simple.SimpleOnesideDiffViewer
-import com.intellij.diff.tools.util.base.DiffViewerBase
 import com.intellij.diff.tools.util.side.TwosideTextDiffViewer
 import com.intellij.diff.util.DiffUtil
 import com.intellij.diff.util.Side
 import com.intellij.notification.NotificationType
-import com.intellij.openapi.Disposable
 import com.intellij.openapi.actionSystem.DataContext
-import com.intellij.openapi.components.Service
 import com.intellij.openapi.components.ServiceManager
 import com.intellij.openapi.editor.Caret
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.editor.actionSystem.EditorAction
 import com.intellij.openapi.editor.actionSystem.EditorActionHandler
 import com.intellij.openapi.editor.ex.EditorEx
-import com.intellij.openapi.editor.impl.event.MarkupModelListener
 import com.intellij.openapi.progress.util.ProgressIndicatorBase
-import com.intellij.openapi.project.Project
+import com.intellij.openapi.project.Project as IdeaProject
 import com.intellij.openapi.vcs.changes.Change
 import com.intellij.openapi.vcs.changes.actions.diff.ChangeDiffRequestProducer.CHANGE_KEY
-import net.ntworld.mergeRequestIntegrationIde.service.ProjectService
+import net.ntworld.mergeRequestIntegrationIde.service.ApplicationService
 import java.awt.event.InputEvent.SHIFT_MASK
 import java.awt.event.KeyEvent.VK_V
 
-@Service
-class ReviewCommentsSupport(private val project: Project) {
-
-    fun installExtensions(viewer: DiffViewerBase, request: ContentDiffRequest) {
+class DiffExtensionInstaller(
+    private val applicationService: ApplicationService,
+    private val context: DiffContext,
+    private val viewer: FrameDiffTool.DiffViewer,
+    private val request: DiffRequest
+) {
+    fun install() {
         when (viewer) {
             is SimpleOnesideDiffViewer -> {
                 println("Simple oneside viewer")
-                OneSideViewerCommentsController(viewer, viewer.request.getUserData(CHANGE_KEY)!!)
+                OneSideViewerCommentsController(applicationService, viewer, viewer.request.getUserData(CHANGE_KEY)!!)
             }
             is TwosideTextDiffViewer -> {
                 println("Side by side viewer")
                 val editor = viewer.getEditor(Side.RIGHT)
 
-                CreateCommentAtRightAction(viewer)
+                CreateCommentAtRightAction(applicationService, viewer)
                         .registerCustomShortcutSet(VK_V, SHIFT_MASK, editor.component)
             }
             is UnifiedDiffViewer -> println("Unified viewer")
             else -> println("Unsupported viewer")
         }
-
-
     }
 
-    class CreateCommentAtRightAction(
-            val viewer: TwosideTextDiffViewer
+    private class CreateCommentAtRightAction(
+        private val applicationService: ApplicationService,
+        val viewer: TwosideTextDiffViewer
     ) : EditorAction(object : EditorActionHandler() {
 
         override fun doExecute(editor: Editor, caret: Caret?, dataContext: DataContext?) {
@@ -98,15 +98,14 @@ class ReviewCommentsSupport(private val project: Project) {
             val lineNumber = viewer.currentSide.other().select(fragmentBuilder.convertor1, fragmentBuilder.convertor2)
                     ?.convert(position.line) //converter works with index position
 
-            ProjectService.getInstance(editor.project!!)
+            val projectService = applicationService.getProjectService(editor.project!!)
+            projectService
                     .notify("caret position: ${position.line + 1}\n " +
                             "line number: ${lineNumber?.plus(1) ?: "null"}\n" +
                             "file path: $originalFilePath",
                             NotificationType.INFORMATION)
 
-            val codeReviewManager = ProjectService.getInstance(editor.project!!)
-                    .codeReviewManager!!
-
+            val codeReviewManager = projectService.codeReviewManager!!
 
             val gitRepository = codeReviewManager.repository
             val mergeRequest = codeReviewManager.mergeRequest
@@ -114,10 +113,7 @@ class ReviewCommentsSupport(private val project: Project) {
             val changeInfo = codeReviewManager
                     .findChangeInfoByPathAndContent(originalFilePath!!, editor.document.text)
 
-            ProjectService.getInstance(editor.project!!)
-                    .notify(changeInfo.toString(),
-                            NotificationType.INFORMATION)
-
+            projectService.notify(changeInfo.toString(), NotificationType.INFORMATION)
         }
     })
 
@@ -135,7 +131,7 @@ class ReviewCommentsSupport(private val project: Project) {
 
     companion object {
         @JvmStatic
-        fun getInstance(project: Project): ReviewCommentsSupport =
-                ServiceManager.getService(project, ReviewCommentsSupport::class.java)
+        fun getInstance(project: IdeaProject): DiffExtensionInstaller =
+                ServiceManager.getService(project, DiffExtensionInstaller::class.java)
     }
 }

--- a/merge-request-integration-core/src/main/kotlin/net/ntworld/mergeRequestIntegrationIde/comments/OneSideViewerCommentsController.kt
+++ b/merge-request-integration-core/src/main/kotlin/net/ntworld/mergeRequestIntegrationIde/comments/OneSideViewerCommentsController.kt
@@ -35,6 +35,7 @@ import com.intellij.util.ui.components.BorderLayoutPanel
 import git4idea.repo.GitRepository
 import net.ntworld.mergeRequest.Comment
 import net.ntworld.mergeRequestIntegrationIde.comments.ui.CommentsThreadComponent
+import net.ntworld.mergeRequestIntegrationIde.service.ApplicationService
 import net.ntworld.mergeRequestIntegrationIde.service.ProjectService
 import net.ntworld.mergeRequestIntegrationIde.ui.util.RepositoryUtil
 import java.awt.*
@@ -51,10 +52,11 @@ import kotlin.math.max
 import kotlin.math.min
 
 class OneSideViewerCommentsController(
+        private val applicationService: ApplicationService,
         private val viewer: SimpleOnesideDiffViewer,
         private val change: Change
 ) {
-
+    private val projectService = applicationService.getProjectService(viewer.project!!)
     private val commentsList: MutableList<Comment> = mutableListOf()
 
     private val editor: EditorImpl = viewer.editor as EditorImpl
@@ -63,7 +65,6 @@ class OneSideViewerCommentsController(
 
     init {
         val project = viewer.project!!
-        val projectService = ProjectService.getInstance(project)
 
         val virtualFile = viewer.editor.virtualFile
 
@@ -72,6 +73,7 @@ class OneSideViewerCommentsController(
         val repository = vcsRepositoryManager.repositories.first() as GitRepository
 
         projectService.codeReviewManager?.comments
+                ?.filter { null !== it.position }
                 ?.forEach { comment: Comment ->
                     if (change.type == Change.Type.NEW
                             && RepositoryUtil.findAbsolutePath(repository, comment.position!!.newPath!!)
@@ -98,8 +100,7 @@ class OneSideViewerCommentsController(
             markupModel.addLineHighlighter(line, HighlighterLayer.LAST, null)
                     .gutterIconRenderer = GutterCommentLineMarkerRenderer(line, object : DumbAwareAction() {
                 override fun actionPerformed(e: AnActionEvent) {
-                    ProjectService.getInstance(viewer.project!!)
-                            .notify("Click on comment ICON", NotificationType.INFORMATION)
+                    projectService.notify("Click on comment ICON", NotificationType.INFORMATION)
 
                     commentsList.takeIf { it.size > 0 }?.let {
                         val comment = it[0]

--- a/merge-request-integration-core/src/main/kotlin/net/ntworld/mergeRequestIntegrationIde/service/ProjectService.kt
+++ b/merge-request-integration-core/src/main/kotlin/net/ntworld/mergeRequestIntegrationIde/service/ProjectService.kt
@@ -1,5 +1,8 @@
 package net.ntworld.mergeRequestIntegrationIde.service
 
+import com.intellij.diff.DiffContext
+import com.intellij.diff.FrameDiffTool
+import com.intellij.diff.requests.DiffRequest
 import com.intellij.notification.NotificationGroup
 import com.intellij.notification.NotificationType
 import com.intellij.openapi.components.ServiceManager
@@ -68,5 +71,4 @@ interface ProjectService {
     fun notify(message: String)
 
     fun notify(message: String, type: NotificationType)
-
 }

--- a/merge-request-integration-ee/src/main/kotlin/net/ntworld/mergeRequestIntegrationIdeEE/DiffExtension.kt
+++ b/merge-request-integration-ee/src/main/kotlin/net/ntworld/mergeRequestIntegrationIdeEE/DiffExtension.kt
@@ -1,0 +1,8 @@
+package net.ntworld.mergeRequestIntegrationIdeEE
+
+import com.intellij.openapi.components.ServiceManager
+import net.ntworld.mergeRequestIntegrationIde.comments.DiffExtensionBase
+
+class DiffExtension : DiffExtensionBase(
+    ServiceManager.getService(EnterpriseApplicationService::class.java)
+)

--- a/merge-request-integration-ee/src/main/resources/META-INF/plugin.xml
+++ b/merge-request-integration-ee/src/main/resources/META-INF/plugin.xml
@@ -14,10 +14,7 @@
     <extensions defaultExtensionNs="com.intellij">
         <applicationService serviceImplementation="net.ntworld.mergeRequestIntegrationIdeEE.EnterpriseApplicationService"/>
         <projectService serviceImplementation="net.ntworld.mergeRequestIntegrationIdeEE.EnterpriseProjectService"/>
-
-        <projectService serviceImplementation="net.ntworld.mergeRequestIntegrationIde.comments.ReviewCommentsSupport"/>
-
-        <diff.DiffExtension implementation="net.ntworld.mergeRequestIntegrationIde.comments.DiffViewerCommentsExtension"/>
+        <diff.DiffExtension implementation="net.ntworld.mergeRequestIntegrationIdeEE.DiffExtension"/>
 
         <projectConfigurable id="merge-request-integration-ee"
                              displayName="Merge Request Integration"


### PR DESCRIPTION
Sorry that I rebased the branch to my master, if you rebase your branch to current dev, you will see the refactor changes only.

What I did:

- Rename `ReviewCommentsSupport` to `DiffExtensionInstaller`, and remove @Service bind of the class. I think we just need only 1 project service.
- Rename `DiffViewerCommentsExtension` to `DiffExtensionBase` and make it open, then I create 2 sub-class for each type of plugin.
- Fix deprecate api `ProjectService.getInstance()`
- Fix bug in `OneSideViewerCommentsController` that general comments has position = null

I agreed with you that we should refactor project to MVP, then use a package as a domain name, each domain will have ui/model/presenter/task folders.

I want to discuss about the package's name. IMHO there are:

- configuration: the domain for configuration pages
- mergeRequest: the domain for merge request covers a details of merge request. This is a big domain, maybe we separate to sub-domain such as: pipeline for pipeline tab, comments for comments tab, etc
- home: the domain for home tab
- diff: ------> this is the main point. I think your work related to diff view, it's not a comments. So does it make sense to rename from `comments` to `diff`?

I'm going to improve further based on your branch, this is the plan:

- Seems `OneSideViewerCommentsController` or `TwosideTextDiffViewer` or `UnifiedDiffViewer` share the same logic such as: filter comments from MR, displays GutterIcon on the line which have comments. So I'm going to create a base class called `AbstractDiffCommentsController` and implements these logic.
- I will add some design to display comments in diff view for all viewers. Maybe I'll use form, then in the future we can refactor or add more features based on this.







